### PR TITLE
feat(health): extend /api/health with Mapbox check

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -45,7 +45,7 @@ export async function GET() {
     checks.supabase = { status: 'fail', detail: String(e) };
   }
 
-  const allOk = Object.values(checks).every((c) => c.status === 'ok');
+  // Mapbox token validity\n  try {\n    const mapboxToken = process.env.NEXT_PUBLIC_MAPBOX_TOKEN;\n    if (!mapboxToken) {\n      checks.mapbox = { status: 'fail', detail: 'Missing NEXT_PUBLIC_MAPBOX_TOKEN' };\n    } else {\n      const res = await fetch(`https://api.mapbox.com/tokens/v2?access_token=${mapboxToken}`, {\n        signal: AbortSignal.timeout(5000),\n      });\n\n      if (res.ok) {\n        const data = await res.json();\n        checks.mapbox =\n          data.code === 'TokenValid'\n            ? { status: 'ok' }\n            : { status: 'fail', detail: `Invalid token: ${JSON.stringify(data)}` };\n      } else {\n        checks.mapbox = { status: 'fail', detail: `HTTP ${res.status}` };\n      }\n    }\n  } catch (e) {\n    checks.mapbox = { status: 'fail', detail: String(e) };\n  }\n\n  const allOk = Object.values(checks).every((c) => c.status === 'ok');
   const duration = Date.now() - start;
 
   return NextResponse.json(


### PR DESCRIPTION
## Summary
- Added a new check to the /api/health endpoint to verify the validity of the Mapbox token.
- The check calls the Mapbox API and reports success if the token is valid, otherwise it reports a failure with the HTTP status or an invalid token message.
- Timeout of 5000ms is used for the API call.

## Test plan
[Bulleted markdown checklist of TODOs for testing the pull request...]

🤖 Generated with [Claude Code](https://claude.com/claude-code)