### PR TITLE
SUMMIT 77c39794 Phase 1b — POST /api/parcel-cards/create (Dify integration point)

### DIFF
--- a/app/api/parcel-cards/create/route.ts
+++ b/app/api/parcel-cards/create/route.ts
@@ -1,0 +1,93 @@
+// app/api/parcel-cards/create/route.ts
+// SUMMIT 77c39794 Phase 1b — public endpoint for card creation
+// Called by:
+//   1. Dify on Hetzner via HTTP node on each completed chat turn
+//   2. Server-side from zoning-chat/route.ts (future integration)
+//   3. BidDeed analysis workers
+//
+// Security: requires INTERNAL_AUTH_TOKEN header (shared secret between Next.js and Dify).
+//          Rate-limited by middleware. Service-role Supabase access is server-side only.
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createParcelCard, type ParcelCardApp, type ParcelCardCitation } from '@/lib/parcel-cards'
+import { SECURITY_HEADERS } from '@/lib/validation'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+const INTERNAL_AUTH = process.env.INTERNAL_AUTH_TOKEN
+if (!INTERNAL_AUTH) {
+  // Don't throw at import time — Vercel build would fail if env missing.
+  // Route handler checks presence at request time.
+  console.warn('[parcel-cards/create] INTERNAL_AUTH_TOKEN not set — route will 503 until configured')
+}
+
+type Body = {
+  parcel_id: number
+  user_id: string | null
+  app: ParcelCardApp
+  question: string
+  answer: { summary: string; confidence?: string; [k: string]: unknown }
+  citations?: ParcelCardCitation[]
+}
+
+function json(status: number, body: unknown) {
+  return NextResponse.json(body, { status, headers: SECURITY_HEADERS })
+}
+
+export async function POST(req: NextRequest) {
+  // 1. Auth
+  if (!INTERNAL_AUTH) return json(503, { error: 'integration_disabled' })
+  const provided = req.headers.get('x-internal-auth')
+  if (provided !== INTERNAL_AUTH) return json(401, { error: 'unauthorized' })
+
+  // 2. Parse + validate
+  let body: Body
+  try {
+    body = (await req.json()) as Body
+  } catch {
+    return json(400, { error: 'invalid_json' })
+  }
+
+  const { parcel_id, user_id, app, question, answer, citations } = body
+  if (typeof parcel_id !== 'number' || parcel_id <= 0) {
+    return json(400, { error: 'invalid_parcel_id' })
+  }
+  if (!['zonewise', 'biddeed'].includes(app)) {
+    return json(400, { error: 'invalid_app' })
+  }
+  if (!question || typeof question !== 'string' || question.length < 3) {
+    return json(400, { error: 'invalid_question' })
+  }
+  if (!answer || typeof answer !== 'object' || !answer.summary) {
+    return json(400, { error: 'invalid_answer' })
+  }
+
+  // 3. Create
+  try {
+    const result = await createParcelCard({
+      parcelId: parcel_id,
+      userId: user_id ?? null,
+      app,
+      question,
+      answer: answer as { summary: string; [k: string]: unknown },
+      citations,
+    })
+    return json(200, {
+      card_id: result.cardId,
+      share_url: result.shareUrl,
+    })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'unknown_error'
+    // FK violations ⇒ 404 (parcel missing), anything else ⇒ 500
+    if (msg.includes('violates foreign key constraint')) {
+      return json(404, { error: 'parcel_not_found' })
+    }
+    return json(500, { error: 'create_failed', detail: msg.slice(0, 200) })
+  }
+}
+
+// Explicit method guards — GET/PUT/DELETE all return 405
+export async function GET() {
+  return json(405, { error: 'method_not_allowed' })
+}

--- a/lib/parcel-cards.ts
+++ b/lib/parcel-cards.ts
@@ -1,0 +1,85 @@
+// lib/parcel-cards.ts
+// SUMMIT 77c39794 Phase 1b — server-side helper for creating parcel cards
+// Called by /api/parcel-cards/create, by Dify on Hetzner, or directly from
+// existing chat routes. Wraps the `create_parcel_card` RPC with typed inputs
+// and a single share URL emitter.
+
+import { createClient } from '@supabase/supabase-js'
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!
+
+if (!SUPABASE_URL) throw new Error('NEXT_PUBLIC_SUPABASE_URL missing')
+if (!SUPABASE_SERVICE_KEY) throw new Error('SUPABASE_SERVICE_ROLE_KEY missing')
+
+export type ParcelCardApp = 'zonewise' | 'biddeed'
+
+export type ParcelCardCitation = {
+  source: string
+  section?: string
+  url?: string
+}
+
+export type ParcelCardAnswer = {
+  summary: string
+  confidence?: 'VERIFIED' | 'UNTESTED' | 'INFERRED'
+  [key: string]: unknown
+}
+
+export type CreateParcelCardInput = {
+  parcelId: number           // zw_parcels.id (bigint)
+  userId: string | null      // auth.users.id uuid, null for anonymous
+  app: ParcelCardApp
+  question: string
+  answer: ParcelCardAnswer
+  citations?: ParcelCardCitation[]
+}
+
+export type CreateParcelCardResult = {
+  cardId: string
+  shareUrl: string
+}
+
+/**
+ * Create a parcel card via the `create_parcel_card` Postgres RPC.
+ * Uses the service-role key (server-only; never import this file from client code).
+ * Returns the card UUID and the public share URL for the appropriate app domain.
+ */
+export async function createParcelCard(
+  input: CreateParcelCardInput,
+): Promise<CreateParcelCardResult> {
+  if (!['zonewise', 'biddeed'].includes(input.app)) {
+    throw new Error(`invalid app: ${input.app}`)
+  }
+  if (!input.question || input.question.length < 3) {
+    throw new Error('question too short')
+  }
+  if (!input.answer?.summary) {
+    throw new Error('answer.summary required')
+  }
+
+  const sb = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY, {
+    auth: { persistSession: false },
+  })
+
+  const { data, error } = await sb.rpc('create_parcel_card', {
+    p_parcel_id: input.parcelId,
+    p_user_id: input.userId,
+    p_app: input.app,
+    p_question: input.question.slice(0, 1000),
+    p_answer: input.answer,
+    p_citations: input.citations ?? [],
+  })
+
+  if (error) throw new Error(`create_parcel_card rpc: ${error.message}`)
+  if (!data || typeof data !== 'string') {
+    throw new Error('create_parcel_card returned no card id')
+  }
+
+  const cardId = data
+  const host = input.app === 'zonewise' ? 'zonewise.ai' : 'biddeed.ai'
+  const pathPart = input.app === 'zonewise' ? 'parcel' : 'property'
+  const shareUrl = `https://${host}/${pathPart}/${cardId}`
+
+  return { cardId, shareUrl }
+}


### PR DESCRIPTION
## SUMMIT 77c39794 Phase 1b — Parcel Card Creation API

Complements PR #90 (the renderer side). This PR adds the **creation side** of the viral loop: a typed, auth-gated endpoint that Dify on Hetzner — or any internal service — POSTs to on each completed chat turn to mint a shareable parcel card.

### What this PR ships

- `lib/parcel-cards.ts` — typed server-only helper wrapping the `create_parcel_card` RPC. Emits share URL in the right domain per `app` (`zonewise.ai` or `biddeed.ai`).
- `app/api/parcel-cards/create/route.ts` — POST endpoint with shared-secret auth (`x-internal-auth` header), input validation, FK-violation → 404 mapping, and explicit 405 on non-POST.

### Why a dedicated route (not a zoning-chat integration)

- Zero modifications to the 879-line `app/api/zoning-chat/route.ts` — keeps review surface minimal.
- Dify can hit it directly from its HTTP-request node — no coupling to chat v1 vs v2.
- BidDeed workers hit the same endpoint with `"app": "biddeed"` — single integration point, two products.
- Future: zoning-chat route can call the helper directly (no HTTP hop) in a follow-up.

### Required env vars

On Vercel `prj_EaXgEO6WDoSpCeLhuCemtbPr6e8E`:

```
SUPABASE_SERVICE_ROLE_KEY  = <from Supabase dashboard>   # server-only, NEVER public
INTERNAL_AUTH_TOKEN        = <new shared secret>         # 32-char random, shared with Dify
NEXT_PUBLIC_SUPABASE_URL   = https://mocerqjnksmhcjzxrewo.supabase.co   # already set per PR #90
```

### Hard verification (ghost-success-proof)

Attached script `smoke-dify-parcel-cards.sh` at `breverdbidder/everest-content/scripts/smoke-dify-parcel-cards.sh` runs three checks:

1. POST to `/api/parcel-cards/create` with test payload → expects `200` + `card_id`
2. SELECT from `parcel_cards_public` by that `card_id` → expects exactly 1 row
3. GET the share URL → expects `200` (warn-only if deploy not propagated)

Exit 0 only when all three pass. Use this as the CI/CD gate post-deploy and as the SUMMIT completion signal — not just "workflow ran".

### API contract

```
POST /api/parcel-cards/create
Headers:
  Content-Type: application/json
  x-internal-auth: <INTERNAL_AUTH_TOKEN>
Body:
  {
    "parcel_id": 12345,              // bigint, zw_parcels.id
    "user_id":   "uuid-or-null",
    "app":       "zonewise" | "biddeed",
    "question":  "string, 3..1000 chars",
    "answer":    { "summary": "...", "confidence": "VERIFIED" | "UNTESTED" | "INFERRED", ... },
    "citations": [{ "source": "...", "section": "...", "url": "..." }]
  }
Responses:
  200 → { card_id: "uuid", share_url: "https://..." }
  400 → { error: "invalid_parcel_id" | "invalid_app" | "invalid_question" | "invalid_answer" | "invalid_json" }
  401 → { error: "unauthorized" }                  // auth header missing/wrong
  404 → { error: "parcel_not_found" }              // FK violation: zw_parcels.id doesn't exist
  405 → { error: "method_not_allowed" }            // non-POST
  500 → { error: "create_failed", detail: "..." }  // unknown Supabase/RPC error
  503 → { error: "integration_disabled" }          // INTERNAL_AUTH_TOKEN missing
```

### Not in this PR

- Dify workflow config on Hetzner (HTTP node pointing at this endpoint) — narrow SUMMIT follows.
- OpenAI/Anthropic cost attribution for the generated answer — Phase 2.

### Related

- PR #90 (renderer): https://github.com/breverdbidder/zonewise-web/pull/90
- SUMMIT: `summit_chat_dispatch.id = '77c39794-79ac-4030-bde8-85a417c2ad3b'`
- Supabase RPC: `public.create_parcel_card` (already live)

---

*Memory: `[mem:ZW_GTM]`, `[mem:PAIRING_RULE]`, `[mem:HONESTY_PROTOCOL]`, `[mem:GHOST_SUCCESS_BANNED]`.*
