### PR TITLE
feat(report): render BidDeed S5 18-section report as HTML at /report?mca_id=

### DIFF
--- a/__tests__/api/report.test.ts
+++ b/__tests__/api/report.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { setTestEnv } from '../helpers/setup'
+
+setTestEnv()
+
+const TEMPLATE_ROWS = [
+  { section_key: 'subject_identification', section_label: '1', title: 'Subject', report_field: 'cover', band_color: 'navy', sort_order: 10 },
+  { section_key: 'auction_outcome', section_label: '18', title: 'Outcome', report_field: 'auction_outcome', band_color: 'green', sort_order: 120 },
+]
+
+let subscriptionRow: { status: string } | null = null
+
+const mockFrom = vi.fn((table: string) => {
+  if (table === 'v_s5_report_template') {
+    return { select: () => ({ order: () => Promise.resolve({ data: TEMPLATE_ROWS, error: null }) }) }
+  }
+  if (table === 'subscriptions') {
+    return {
+      select: () => ({
+        eq: () => ({
+          eq: () => ({ single: () => Promise.resolve({ data: subscriptionRow, error: subscriptionRow ? null : { message: 'no rows' } }) }),
+        }),
+      }),
+    }
+  }
+  if (table === 'multi_county_auctions') {
+    return {
+      select: () => ({
+        ilike: () => ({ limit: () => ({ maybeSingle: () => Promise.resolve({ data: { id: 999 }, error: null }) }) }),
+      }),
+    }
+  }
+  return { select: () => ({ order: () => Promise.resolve({ data: [], error: null }) }) }
+})
+
+const mockRpc = vi.fn().mockResolvedValue({ data: null, error: { message: 'unavailable' } })
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({ from: mockFrom, rpc: mockRpc })),
+}))
+
+let clerkUserId: string | null = null
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: vi.fn(async () => ({ userId: clerkUserId })),
+}))
+
+describe('GET /api/report — server-side entitlement gate', () => {
+  let GET: typeof import('@/app/api/report/route').GET
+
+  beforeEach(async () => {
+    clerkUserId = null
+    subscriptionRow = null
+    vi.clearAllMocks()
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'unavailable' } })
+    vi.stubGlobal('fetch', vi.fn())
+    // resolveServerKey() caches its result at module scope (by design, to
+    // avoid a vault round-trip per request) — reset the module registry per
+    // test so that cache doesn't leak between differently-keyed test cases.
+    vi.resetModules()
+    ;({ GET } = await import('@/app/api/report/route'))
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    delete process.env.BIDDEED_MCP_SERVER_KEY
+  })
+
+  it('signed-out caller never triggers the MCP report fetch and gets no report data', async () => {
+    process.env.BIDDEED_MCP_SERVER_KEY = 'bd_live_should_never_be_used'
+    const req = new NextRequest('http://localhost/api/report?mca_id=abc123')
+    const res = await GET(req)
+    const body = await res.json()
+
+    expect(body.entitled).toBe(false)
+    expect(body.report).toBeNull()
+    // The negative test: full S5 data must never be produced for a non-entitled
+    // caller — proven by asserting the MCP engine (global fetch) was never hit.
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('signed-in caller without an active subscription is treated as non-Pro', async () => {
+    clerkUserId = 'user_123'
+    subscriptionRow = null // no active row
+    const req = new NextRequest('http://localhost/api/report?mca_id=abc123')
+    const res = await GET(req)
+    const body = await res.json()
+
+    expect(body.entitled).toBe(false)
+    expect(body.report).toBeNull()
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('entitled Pro caller fetches the full S5 report from the MCP engine with a server-held key', async () => {
+    clerkUserId = 'user_pro'
+    subscriptionRow = { status: 'active' }
+    process.env.BIDDEED_MCP_SERVER_KEY = 'bd_live_test_key'
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ mca_id: 'abc123', report: { cover: { verdict: 'BID' } } }),
+    })
+
+    const req = new NextRequest('http://localhost/api/report?mca_id=abc123')
+    const res = await GET(req)
+    const body = await res.json()
+
+    expect(body.entitled).toBe(true)
+    expect(body.report?.cover?.verdict).toBe('BID')
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+    const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(String(url)).toContain('/report/json?mca_id=abc123')
+    expect((init?.headers as Record<string, string>)?.Authorization).toBe('Bearer bd_live_test_key')
+  })
+
+  it('entitled Pro caller with no server key gets a graceful pending state, never a crash', async () => {
+    clerkUserId = 'user_pro'
+    subscriptionRow = { status: 'active' }
+    // BIDDEED_MCP_SERVER_KEY intentionally unset; vault RPC mocked to fail above.
+
+    const req = new NextRequest('http://localhost/api/report?mca_id=abc123')
+    const res = await GET(req)
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.entitled).toBe(true)
+    expect(body.report).toBeNull()
+    expect(body.error).toMatch(/server key not configured/)
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('no mca_id and no address renders the picker state, never crashes', async () => {
+    const req = new NextRequest('http://localhost/api/report')
+    const res = await GET(req)
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.selected).toBe(false)
+    expect(Array.isArray(body.template)).toBe(true)
+  })
+})

--- a/app/(dashboard)/report/page.tsx
+++ b/app/(dashboard)/report/page.tsx
@@ -1,25 +1,120 @@
 export const dynamic = 'force-dynamic'
 
-import { notFound } from 'next/navigation'
 import type { Metadata } from 'next'
+import type { ReactNode } from 'react'
 import Link from 'next/link'
-import { ArrowLeft, AlertTriangle } from 'lucide-react'
+import { ArrowLeft, AlertTriangle, FileSearch, Lock } from 'lucide-react'
 import ZoningReport, { type ZoningReportData } from '@/components/reports/ZoningReport'
 import ErrorBoundary from '@/components/ErrorBoundary'
 import ZoningDisclaimer from '@/components/ZoningDisclaimer'
+import S5Report from '@/components/report/S5Report'
+import type { S5TemplateRow } from '@/app/api/report/route'
 
 interface ReportPageProps {
-  searchParams: Promise<{ parcel?: string; print?: string }>
+  searchParams: Promise<{ parcel?: string; mca_id?: string; address?: string; print?: string }>
+}
+
+function resolveBaseUrl(): string {
+  return process.env.VERCEL_URL
+    ? `https://${process.env.VERCEL_URL}`
+    : process.env.NEXT_PUBLIC_BASE_URL ?? 'https://zonewise.ai'
 }
 
 export async function generateMetadata({ searchParams }: ReportPageProps): Promise<Metadata> {
-  const { parcel } = await searchParams
+  const { parcel, mca_id: mcaId } = await searchParams
+  if (mcaId) {
+    return {
+      title: `BidDeed S5 Report: ${mcaId} — ZoneWise.AI`,
+      description: 'Full BidDeed S5 18-section property intelligence report.',
+      robots: 'noindex',
+    }
+  }
   if (!parcel) return { title: 'Property Zoning Report — ZoneWise.AI' }
   return {
     title: `Zoning Report: ${decodeURIComponent(parcel)} — ZoneWise.AI`,
     description: `Full property zoning report for parcel ${decodeURIComponent(parcel)} in Brevard County, FL`,
     robots: 'noindex',
   }
+}
+
+interface S5ApiResponse {
+  selected: boolean
+  entitled?: boolean
+  mca_id?: string
+  template: S5TemplateRow[]
+  report: Record<string, unknown> | null
+  error?: string
+}
+
+async function fetchS5Report(params: { mca_id?: string; address?: string }): Promise<S5ApiResponse | null> {
+  try {
+    const qs = new URLSearchParams(
+      params.mca_id ? { mca_id: params.mca_id } : { address: params.address ?? '' }
+    )
+    const res = await fetch(`${resolveBaseUrl()}/api/report?${qs.toString()}`, { cache: 'no-store' })
+    // 404 (address not found) still carries a body worth showing — read it either way.
+    const body = await res.json().catch(() => null)
+    return body
+  } catch {
+    return null
+  }
+}
+
+function S5Picker() {
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center bg-white dark:bg-slate-950 p-8 gap-4 min-h-[60vh]">
+      <div className="w-14 h-14 rounded-full bg-[#1E3A5F]/10 dark:bg-[#1E3A5F]/30 flex items-center justify-center">
+        <FileSearch className="w-7 h-7 text-[#1E3A5F] dark:text-[#F59E0B]" />
+      </div>
+      <div className="text-center max-w-sm">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">Select a Property Report</h2>
+        <p className="text-sm text-gray-500 dark:text-slate-400">
+          Open a BidDeed S5 report with <code className="text-xs bg-gray-100 dark:bg-slate-800 px-1 rounded">?mca_id=</code>,
+          or a ZoneWise zoning report with <code className="text-xs bg-gray-100 dark:bg-slate-800 px-1 rounded">?parcel=</code>.
+        </p>
+      </div>
+      <Link href="/chat" className="flex items-center gap-2 px-4 py-2 rounded-lg bg-[#1E3A5F] text-white text-sm font-medium hover:bg-[#1E3A5F]/80 transition-colors">
+        <ArrowLeft className="w-4 h-4" />
+        Back to ZoneWise Chat
+      </Link>
+    </div>
+  )
+}
+
+function S5Teaser({ mcaId }: { mcaId?: string }) {
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center bg-white dark:bg-slate-950 p-8 gap-4 min-h-[60vh]">
+      <div className="w-14 h-14 rounded-full bg-amber-100 dark:bg-amber-900/20 flex items-center justify-center">
+        <Lock className="w-7 h-7 text-amber-600 dark:text-amber-400" />
+      </div>
+      <div className="text-center max-w-sm">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">Pro Report Locked</h2>
+        <p className="text-sm text-gray-500 dark:text-slate-400">
+          The full 18-section BidDeed S5 report for <span className="font-mono text-xs">{mcaId}</span> requires a ZoneWise
+          Pro subscription.
+        </p>
+      </div>
+      <Link href="/pricing" className="px-4 py-2 rounded-lg bg-[#F59E0B] text-[#020617] text-sm font-semibold hover:bg-[#F59E0B]/80 transition-colors">
+        Upgrade to Pro
+      </Link>
+    </div>
+  )
+}
+
+function S5Pending({ mcaId, message }: { mcaId?: string; message?: string }) {
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center bg-white dark:bg-slate-950 p-8 gap-4 min-h-[60vh]">
+      <div className="w-14 h-14 rounded-full bg-amber-100 dark:bg-amber-900/20 flex items-center justify-center">
+        <AlertTriangle className="w-7 h-7 text-amber-600 dark:text-amber-400" />
+      </div>
+      <div className="text-center max-w-sm">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">Report Data Pending</h2>
+        <p className="text-sm text-gray-500 dark:text-slate-400">
+          {message || `Could not generate a report for ${mcaId ?? 'this property'} right now.`}
+        </p>
+      </div>
+    </div>
+  )
 }
 
 async function fetchReportData(parcelId: string, origin: string): Promise<ZoningReportData | null> {
@@ -34,22 +129,58 @@ async function fetchReportData(parcelId: string, origin: string): Promise<Zoning
 }
 
 export default async function ReportPage({ searchParams }: ReportPageProps) {
-  const { parcel, print } = await searchParams
+  const { parcel, mca_id: mcaId, address, print } = await searchParams
+
+  // BidDeed S5 report (new) — takes priority when present, never collides
+  // with the existing ?parcel= ZoneWise zoning report below.
+  if (mcaId || address) {
+    const s5 = await fetchS5Report({ mca_id: mcaId, address })
+    const isPrint = print === '1'
+
+    let body: ReactNode
+    if (!s5) {
+      body = <S5Pending mcaId={mcaId} message="Report service unavailable — try again shortly." />
+    } else if (s5.entitled === false) {
+      body = <S5Teaser mcaId={s5.mca_id ?? mcaId} />
+    } else if (!s5.report) {
+      body = <S5Pending mcaId={s5.mca_id ?? mcaId} message={s5.error} />
+    } else {
+      body = <S5Report template={s5.template} report={s5.report} />
+    }
+
+    return (
+      <div className={`min-h-screen bg-gray-50 dark:bg-slate-950 ${isPrint ? 'print-mode' : ''}`}>
+        {!isPrint && (
+          <div className="sticky top-0 z-10 bg-white dark:bg-slate-900 border-b border-gray-200 dark:border-slate-700 px-4 py-3 flex items-center justify-between print:hidden">
+            <Link
+              href="/chat"
+              className="flex items-center gap-2 text-sm text-gray-600 dark:text-slate-300 hover:text-gray-900 dark:hover:text-white transition-colors"
+            >
+              <ArrowLeft className="w-4 h-4" />
+              Back to Chat
+            </Link>
+            <div className="flex items-center gap-2">
+              <div className="w-6 h-6 rounded bg-[#020617] flex items-center justify-center">
+                <span className="text-[#F59E0B] text-xs font-bold">B</span>
+              </div>
+              <span className="text-sm font-semibold text-gray-900 dark:text-white">BidDeed.AI S5 Report</span>
+            </div>
+          </div>
+        )}
+        <div className="py-6 px-4">
+          <ErrorBoundary>{body}</ErrorBoundary>
+        </div>
+      </div>
+    )
+  }
 
   if (!parcel) {
-    notFound()
+    return <S5Picker />
   }
 
   const parcelId = decodeURIComponent(parcel)
 
-  // For server-side rendering, construct absolute URL using a known base
-  // Vercel provides VERCEL_URL; fall back to production URL
-  const baseUrl =
-    process.env.VERCEL_URL
-      ? `https://${process.env.VERCEL_URL}`
-      : process.env.NEXT_PUBLIC_BASE_URL ?? 'https://zonewise.ai'
-
-  const data = await fetchReportData(parcelId, baseUrl)
+  const data = await fetchReportData(parcelId, resolveBaseUrl())
 
   if (!data) {
     return (

--- a/app/api/report/route.ts
+++ b/app/api/report/route.ts
@@ -1,0 +1,145 @@
+export const dynamic = 'force-dynamic'
+
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@clerk/nextjs/server'
+import { createClient } from '@supabase/supabase-js'
+import { createServiceClient } from '@/lib/supabase/server'
+import { SECURITY_HEADERS } from '@/lib/validation'
+import { fetchS5Report, type ServerKeySource } from '@/lib/biddeed-mcp'
+
+const MCA_ID_RE = /^[A-Za-z0-9._-]{1,64}$/
+
+export interface S5TemplateRow {
+  section_key: string
+  section_label: string
+  title: string
+  report_field: string | null
+  band_color: string | null
+  sort_order: number
+}
+
+// ─── Server-side Pro entitlement check ─────────────────────────────────────
+// Same source of truth as app/api/zoning-chat/route.ts checkProEntitlement —
+// derived from the authenticated Clerk session + subscriptions table, never
+// from a client-supplied flag.
+async function checkProEntitlement(): Promise<boolean> {
+  try {
+    const { userId } = await auth()
+    if (!userId) return false
+    if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) return false
+
+    const supabaseAdmin = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL,
+      process.env.SUPABASE_SERVICE_ROLE_KEY
+    )
+    const { data } = await supabaseAdmin
+      .from('subscriptions')
+      .select('status')
+      .eq('user_id', userId)
+      .eq('status', 'active')
+      .single()
+
+    return !!data
+  } catch {
+    return false
+  }
+}
+
+async function loadTemplate(): Promise<S5TemplateRow[]> {
+  const supabase = createServiceClient()
+  const { data, error } = await supabase
+    .from('v_s5_report_template')
+    .select('section_key,section_label,title,report_field,band_color,sort_order')
+    .order('sort_order', { ascending: true })
+  if (error || !data) return []
+  return data as S5TemplateRow[]
+}
+
+async function resolveMcaIdFromAddress(address: string): Promise<string | null> {
+  const supabase = createServiceClient()
+  const { data } = await supabase
+    .from('multi_county_auctions')
+    .select('id')
+    .ilike('property_address', `%${address}%`)
+    .limit(1)
+    .maybeSingle()
+  return data?.id != null ? String(data.id) : null
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = req.nextUrl
+  const rawMcaId = searchParams.get('mca_id')?.trim()
+  const rawAddress = searchParams.get('address')?.trim()
+
+  if (!rawMcaId && !rawAddress) {
+    // No identifying param — the page renders a picker for this, and the API
+    // mirrors that: an empty, non-error "nothing selected yet" response.
+    return NextResponse.json(
+      { selected: false, template: await loadTemplate() },
+      { headers: SECURITY_HEADERS }
+    )
+  }
+
+  let mcaId: string | null = null
+  if (rawMcaId) {
+    if (!MCA_ID_RE.test(rawMcaId)) {
+      return NextResponse.json({ error: 'Invalid mca_id' }, { status: 400, headers: SECURITY_HEADERS })
+    }
+    mcaId = rawMcaId
+  } else if (rawAddress) {
+    if (rawAddress.length < 3 || rawAddress.length > 200) {
+      return NextResponse.json({ error: 'Invalid address' }, { status: 400, headers: SECURITY_HEADERS })
+    }
+    mcaId = await resolveMcaIdFromAddress(rawAddress)
+    if (!mcaId) {
+      return NextResponse.json(
+        { error: 'No auction found for that address', address: rawAddress },
+        { status: 404, headers: SECURITY_HEADERS }
+      )
+    }
+  }
+
+  const template = await loadTemplate()
+  const entitled = await checkProEntitlement()
+
+  // Non-entitled callers never trigger the MCP report fetch — the full S5
+  // JSON is simply never produced for this request, not filtered after the
+  // fact. Server-derived gate only; no client-supplied flag is trusted.
+  if (!entitled) {
+    return NextResponse.json(
+      { selected: true, entitled: false, mca_id: mcaId, template, report: null },
+      { headers: SECURITY_HEADERS }
+    )
+  }
+
+  const result = await fetchS5Report(mcaId!)
+  if (!result.ok) {
+    const pending = result.keySource === 'none'
+    return NextResponse.json(
+      {
+        selected: true,
+        entitled: true,
+        mca_id: mcaId,
+        template,
+        report: null,
+        error: pending
+          ? 'report data pending — server key not configured'
+          : result.error,
+        keySource: result.keySource satisfies ServerKeySource,
+      },
+      { status: pending ? 200 : (result.status || 502), headers: SECURITY_HEADERS }
+    )
+  }
+
+  return NextResponse.json(
+    {
+      selected: true,
+      entitled: true,
+      mca_id: mcaId,
+      template,
+      report: result.data.report,
+      keySource: result.keySource satisfies ServerKeySource,
+    },
+    { headers: SECURITY_HEADERS }
+  )
+}

--- a/components/report/S5Report.tsx
+++ b/components/report/S5Report.tsx
@@ -1,0 +1,382 @@
+// Renders the BidDeed S5 18-section property intelligence report as HTML.
+// Layout/content mirrors packages/biddeed-mcp/src/report/pdf.js section-for-
+// section (the canonical PDF renderer) — this is the HTML twin, not a fork
+// of the report math. Data comes from GET /api/report (server-fetched from
+// the BidDeed MCP report engine); this component only formats it.
+import type { ReactNode } from 'react'
+import type { S5TemplateRow } from '@/app/api/report/route'
+
+const BAND_COLOR: Record<string, string> = {
+  navy: '#1E3A5F',
+  orange: '#F59E0B',
+  green: '#16A34A',
+  red: '#DC2626',
+  amber: '#D97706',
+}
+
+type Report = Record<string, any>
+
+function money(val: unknown): string {
+  if (val == null || val === '') return 'Pending'
+  const n = typeof val === 'object' && val !== null ? (val as any).value : val
+  if (n == null) return typeof val === 'object' && val !== null && (val as any).display ? (val as any).display : 'Pending'
+  return `$${Number(n).toLocaleString('en-US', { maximumFractionDigits: 0 })}`
+}
+
+function pct(val: unknown): string {
+  return val == null ? 'Pending' : `${(Number(val) * 100).toFixed(1)}%`
+}
+
+function safeStr(val: unknown, fallback = 'Pending'): string {
+  if (val == null || val === '' || val === 'null') return fallback
+  if (typeof val === 'object' && val !== null && (val as any).display) return (val as any).display
+  return String(val)
+}
+
+function Band({ label, title, color }: { label: string; title: string; color: string | null }) {
+  return (
+    <div
+      className="px-4 py-2 rounded-t-md text-white text-sm font-bold tracking-wide"
+      style={{ backgroundColor: BAND_COLOR[color ?? 'navy'] ?? BAND_COLOR.navy }}
+    >
+      §{label} {title.toUpperCase()}
+    </div>
+  )
+}
+
+function Row({ label, value, alt }: { label: string; value: unknown; alt?: boolean }) {
+  return (
+    <div className={`flex justify-between px-4 py-2 text-sm ${alt ? 'bg-slate-50 dark:bg-slate-900' : 'bg-white dark:bg-slate-950'}`}>
+      <span className="text-slate-500 dark:text-slate-400">{label}</span>
+      <span className="font-semibold text-slate-900 dark:text-white text-right">{safeStr(value)}</span>
+    </div>
+  )
+}
+
+function TwoCol({ pairs }: { pairs: [string, unknown][] }) {
+  return (
+    <div className="grid grid-cols-2 gap-px bg-slate-200 dark:bg-slate-800">
+      {pairs.map(([l, v], i) => (
+        <div key={l} className={`flex justify-between px-3 py-2 text-sm ${i % 4 < 2 ? 'bg-slate-50 dark:bg-slate-900' : 'bg-white dark:bg-slate-950'}`}>
+          <span className="text-slate-500 dark:text-slate-400">{l}</span>
+          <span className="font-semibold text-slate-900 dark:text-white text-right">{safeStr(v)}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function LiabilityNote({ note }: { note?: string | null }) {
+  if (!note) return null
+  return <p className="px-4 py-2 text-xs italic text-amber-600 dark:text-amber-400">⚠ {note}</p>
+}
+
+// ─── Section renderers — keyed by section_key, mirroring pdf.js ────────────
+const SECTION_RENDERERS: Record<string, (report: Report) => ReactNode> = {
+  subject_identification(report) {
+    const cover = report.cover || {}
+    const auction = report.auction_listing || {}
+    return (
+      <>
+        <Row label="Address" value={cover.property_address} alt />
+        <Row label="County" value={cover.county ? `${String(cover.county).toUpperCase()} County, Florida` : null} />
+        <Row label="Case Number" value={cover.case_number} alt />
+        <Row label="Sale Type" value={cover.sale_type} />
+        <Row label="Auction Date" value={auction.auction_date || cover.auction_date} alt />
+        <Row label="Plaintiff" value={auction.plaintiff || cover.plaintiff} />
+        <Row label="Assessed Value" value={money(auction.assessed_value)} alt />
+        <Row label="Final Judgment" value={money(auction.judgment_amount)} />
+        <Row label="Plaintiff Max Bid" value={money(auction.plaintiff_max_bid)} alt />
+        <Row label="Gold Standard" value={cover.cert_status || 'Standard'} />
+      </>
+    )
+  },
+
+  value_estimate(report) {
+    const value = report.value_estimate
+    const cover = report.cover || {}
+    if (!value || value.midpoint == null) {
+      return <Row label="Value Estimate" value="Pending — parcel not located in fl_parcels" />
+    }
+    const cb = value.clearing_band
+    const mb = value.market_band
+    return (
+      <>
+        <div className="m-3 p-3 rounded bg-amber-50 dark:bg-amber-950/30">
+          <p className="text-xs font-bold text-amber-700 dark:text-amber-400">EXPECTED CLEARING PRICE (Distressed)</p>
+          <p className="text-lg font-bold text-[#1E3A5F] dark:text-white">{cb?.low != null ? `${money(cb.low)} – ${money(cb.high)}` : 'Pending'}</p>
+          {cb?.midpoint != null && <p className="text-xs text-slate-500">Midpoint {money(cb.midpoint)}</p>}
+        </div>
+        <div className="m-3 p-3 rounded bg-green-50 dark:bg-green-950/30">
+          <p className="text-xs font-bold text-green-700 dark:text-green-400">RETAIL ARV — OPEN MARKET EXIT VALUE</p>
+          <p className="text-lg font-bold text-[#1E3A5F] dark:text-white">{mb?.low != null ? `${money(mb.low)} – ${money(mb.high)}` : 'Pending'}</p>
+          {mb?.midpoint != null && (
+            <p className="text-xs text-slate-500">
+              Midpoint {money(mb.midpoint)} · Investment Grade {cover.investment_grade || '—'} · Shapira Max Bid {money(cover.shapira_max_bid)}
+            </p>
+          )}
+        </div>
+        {cover.equity_at_entry_bid != null && (
+          <div className="mx-3 mb-3 p-3 rounded bg-green-600 text-white text-sm font-bold">
+            Day-1 Equity at Entry Bid: {money(cover.equity_at_entry_bid)} · Equity at Ceiling: {money(cover.equity_at_ceiling)}
+          </div>
+        )}
+        {Array.isArray(value.anchors) && value.anchors.length > 0 && (
+          <div className="px-3 pb-2">
+            <p className="text-xs font-bold text-slate-500 mb-1">Value Anchors:</p>
+            {value.anchors.map((a: any, i: number) => (
+              <Row key={a.key} label={a.key.replace(/_/g, ' ')} value={a.value != null ? `${money(a.value)} · ${a.source}` : `Pending — ${a.source}`} alt={i % 2 === 0} />
+            ))}
+          </div>
+        )}
+      </>
+    )
+  },
+
+  market_and_comps(report) {
+    const cma = report.cma || {}
+    const distressed = report.cma_distressed || {}
+    const retailComps: any[] = Array.isArray(cma.comps) ? cma.comps : []
+    const auctionComps: any[] = Array.isArray(distressed.comps) ? distressed.comps : []
+    return (
+      <>
+        <p className="px-4 pt-3 pb-1 text-sm font-bold text-[#1E3A5F] dark:text-white">
+          LAYER 1 — Auction Market Comps (Distressed)
+        </p>
+        {distressed.n_county_outcomes > 0 ? (
+          <>
+            <TwoCol
+              pairs={[
+                ['County Outcomes', `${distressed.n_county_outcomes} sold (${distressed.since_year}→)`],
+                ['Median Clearing Ratio', distressed.median_clearing_ratio_sold_to_assessed ? `${pct(distressed.median_clearing_ratio_sold_to_assessed)} of assessed` : '—'],
+                ['Distressed Median $', money(distressed.median_distressed_price)],
+                ['Implied Clearing (Subject)', money(distressed.implied_clearing_price_for_subject)],
+              ]}
+            />
+            {auctionComps.map((c, i) => (
+              <Row key={i} label={c.address || '—'} value={`Sold ${money(c.sold_amount)} · ${c.clearing_pct_of_assessed != null ? c.clearing_pct_of_assessed + '%' : '—'} · ${c.auction_date ? String(c.auction_date).slice(0, 10) : '—'}`} alt={i % 2 === 0} />
+            ))}
+          </>
+        ) : (
+          <Row label="Distressed CMA" value={distressed.note || 'Pending — no auction-cleared comps found for this county/sqft range'} />
+        )}
+        <p className="px-4 pt-3 pb-1 text-sm font-bold text-[#1E3A5F] dark:text-white">
+          LAYER 2 — Retail Market Comps (Open Market ARV)
+        </p>
+        {retailComps.length > 0 ? (
+          <>
+            {retailComps.map((c, i) => (
+              <Row key={i} label={c.address || c.property_address || 'Address pending'} value={`Sold ${money(c.sale_price1 ?? c.sold_amount)} · ${c.sale_yr1 ?? c.auction_date ?? ''}`} alt={i % 2 === 0} />
+            ))}
+            {cma.median_sale_price && (
+              <p className="px-4 py-2 text-xs text-slate-500">
+                Retail stats: median {money(cma.median_sale_price)} · n={cma.n} · dispersion {cma.dispersion_flag || '—'}
+              </p>
+            )}
+          </>
+        ) : (
+          <Row label="Retail ARV Comps" value={cma.note || 'Pending — no retail comps returned for this parcel'} />
+        )}
+        {(distressed.implied_clearing_price_for_subject || distressed.median_distressed_price) && cma.median_sale_price && (
+          <div className="mx-3 my-2 p-3 rounded bg-green-50 dark:bg-green-950/30 text-sm font-bold text-green-700 dark:text-green-400">
+            THE SPREAD: Distressed clearing {money(distressed.implied_clearing_price_for_subject || distressed.median_distressed_price)} → Retail ARV {money(cma.median_sale_price)}
+          </div>
+        )}
+      </>
+    )
+  },
+
+  transaction_history(report) {
+    const tx = report.transaction_history || {}
+    return (
+      <>
+        <Row label="Prior Transfer Date" value={tx.prior_sale_date || 'Pending'} alt />
+        <Row label="Prior Transfer Price" value={money(tx.prior_sale_price)} />
+        <Row label="Current Owner" value={report.cover?.current_owner || report.auction_listing?.current_owner || 'Pending'} alt />
+        <Row label="Homestead Status" value={report.property_record?.homestead_status || 'Pending'} />
+      </>
+    )
+  },
+
+  property_record(report) {
+    const prop = report.property_record || {}
+    const auction = report.auction_listing || {}
+    return (
+      <TwoCol
+        pairs={[
+          ['Property Type', prop.property_type || 'Pending'],
+          ['Beds / Baths', `${safeStr(prop.beds)} / ${safeStr(prop.baths)}`],
+          ['Living Area', prop.living_area_sqft ? `${prop.living_area_sqft} sqft` : 'Pending'],
+          ['Year Built', prop.year_built || 'Pending'],
+          ['Lot Size', prop.lot_size_acres ? `${prop.lot_size_acres} ac` : 'Pending'],
+          ['Homestead', prop.homestead_status || 'Pending'],
+          ['Coordinates', report.cover?.coordinates || 'Pending'],
+          ['Auction URL', auction.auction_url || 'Pending'],
+        ]}
+      />
+    )
+  },
+
+  context_layers(report) {
+    const ctx = report.context_layers || {}
+    return (
+      <>
+        <Row label="Market Grade" value={ctx.market_grade || 'Pending'} alt />
+        <Row label="Neighborhood" value={ctx.neighborhood || 'Pending — layer not yet wired for this county'} />
+        <Row label="Schools" value={ctx.schools || 'Pending — GreatSchools layer not yet wired'} alt />
+        <Row label="Flood Zone" value={ctx.flood_zone || 'Pending — FEMA layer not yet wired; verify Zone X vs AE'} />
+        <Row label="Median Income" value={ctx.median_income ? `$${Number(ctx.median_income).toLocaleString()}` : 'Pending'} alt />
+      </>
+    )
+  },
+
+  shapira_ml(report) {
+    const ml = report.context_layers?.ml_model || {}
+    return (
+      <>
+        <Row label="Model" value={ml.model_version || 'v14.0 XGBoost'} alt />
+        <Row label="Trained" value="2026-05-27 · 137,488 samples · 21 features" />
+        <Row label="Accuracy / AUC" value="acc 72.2% · AUC 0.783 · precision 0.716 · recall 0.909 · F1 0.801" alt />
+        {typeof ml.probability_third_party_purchase === 'number' ? (
+          <p className="px-4 py-2 text-xs font-bold text-red-600 dark:text-red-400">
+            NOTE: Live inference probability withheld — a number the model did not produce will not be printed under its name.
+          </p>
+        ) : (
+          <Row label="3rd-Party Probability" value="Withheld — see methodology note above" alt />
+        )}
+      </>
+    )
+  },
+
+  zonewise(report) {
+    const zw = report.zoning || {}
+    return (
+      <>
+        <Row label="State Parcel (DOR)" value={zw.parcel_id || 'Pending'} alt />
+        <Row label="Jurisdiction" value={zw.jurisdiction || 'Pending'} />
+        <Row label="DOR Land Use" value={zw.dor_land_use || 'Pending'} alt />
+        <Row label="Land Tenure (MH)" value={zw.land_tenure || 'Pending'} />
+        <Row label="DOR Just Value" value={money(zw.just_value)} alt />
+        <Row label="District Assignment" value={zw.district || 'PENDING — ZoneWise district layer not yet built for this county'} />
+        <Row label="ZoneWise Verdict" value={zw.verdict || 'Pending'} alt />
+      </>
+    )
+  },
+
+  bid_card(report) {
+    const cover = report.cover || {}
+    const opp = report.opinion_of_price_bid_card || {}
+    const smb = cover.shapira_max_bid
+    const smbVal = typeof smb === 'object' && smb !== null ? smb.value : smb
+    return (
+      <>
+        <div className="m-3 p-3 rounded text-white" style={{ backgroundColor: cover.verdict?.startsWith('BID') ? '#16A34A' : cover.verdict === 'SKIP' ? '#DC2626' : '#D97706' }}>
+          <p className="text-2xl font-bold">{cover.verdict || 'PENDING'}</p>
+          <p className="text-sm">Investment Grade {cover.investment_grade || '—'}</p>
+        </div>
+        <TwoCol
+          pairs={[
+            ['Entry Bid', money(opp.entry_bid || cover.entry_bid)],
+            ['Shapira Max Bid', money(smbVal)],
+            ['Walk Away Above', money(smbVal)],
+            ['Value Midpoint', money(opp.value_midpoint)],
+          ]}
+        />
+      </>
+    )
+  },
+
+  judgment_encumbrance(report) {
+    const j = report.judgment || {}
+    const flags: any[] = report.red_flags || []
+    return (
+      <>
+        <Row label="Recorded CFN" value={j.cfn || 'Pending'} alt />
+        <Row label="Judgment Amount" value={money(j.judgment_amount)} />
+        <Row label="Principal" value={money(j.principal)} alt />
+        <Row label="Interest" value={money(j.interest)} />
+        <Row label="County Tax" value={money(j.county_tax)} alt />
+        <Row label="Hazard Insurance" value={money(j.hazard_insurance)} />
+        <Row label="Fees / Costs" value={money(j.fees)} alt />
+        {flags.map((f, i) => (
+          <div key={i} className={`mx-3 my-1 p-2 border-l-4 text-xs ${f.severity === 'risk' ? 'border-red-600 text-red-700' : f.severity === 'pending' ? 'border-amber-600 text-amber-700' : 'border-green-600 text-green-700'}`}>
+            <span className="font-bold">{f.code || f.label || 'FLAG'}</span> {f.detail || f.text || ''}
+          </div>
+        ))}
+      </>
+    )
+  },
+
+  provenance(report) {
+    const prov = report.provenance || {}
+    return (
+      <>
+        <Row label="Data Sources" value={prov.generated_from || 'multi_county_auctions, fl_parcels, zoning_assignments, shapira_models'} alt />
+        <Row label="Certification" value={prov.certification_disclosure || 'Pending'} />
+        <p className="px-4 py-2 text-xs text-slate-600 dark:text-slate-400">
+          {prov.model_disclosure || 'Shapira Models v14.0 XGBoost — probability withheld rather than approximated.'}
+        </p>
+      </>
+    )
+  },
+
+  auction_outcome(report) {
+    const outcome = report.auction_outcome || {}
+    if (outcome.result || outcome.sale_status) {
+      return (
+        <TwoCol
+          pairs={[
+            ['Result', outcome.sale_status || outcome.result],
+            ['Sale Amount', money(outcome.sale_amount || outcome.winning_bid)],
+            ['Winning Bidder', outcome.winning_bidder || '—'],
+            ['Buyer Type', outcome.buyer_type || '—'],
+            ['Clearing Multiple', outcome.clearing_multiple ? `${outcome.clearing_multiple}×` : '—'],
+            ['3rd-Party Predicted', outcome.predicted_third_party ? 'YES' : 'Withheld'],
+          ]}
+        />
+      )
+    }
+    return (
+      <Row
+        label="Status"
+        value={`Pending — auction scheduled ${report.cover?.auction_date || '—'}. Populates automatically after sale closes.`}
+      />
+    )
+  },
+}
+
+interface S5ReportProps {
+  template: S5TemplateRow[]
+  report: Report
+}
+
+export default function S5Report({ template, report }: S5ReportProps) {
+  const cover = report.cover || {}
+  return (
+    <div className="max-w-3xl mx-auto">
+      <div className="rounded-t-lg bg-[#020617] text-white px-5 py-4">
+        <p className="text-lg font-bold text-[#F59E0B]">BidDeed.AI</p>
+        <p className="text-xs mt-1">PROPERTY INTELLIGENCE REPORT · S5 CLASS</p>
+        <p className="text-xs text-slate-400 mt-1">
+          {(cover.county || '').toUpperCase()} County, FL · {cover.sale_type || 'Foreclosure'} Sale {cover.auction_date || ''} · {cover.property_address || ''}
+        </p>
+        <p className="text-[11px] text-slate-500 mt-1">
+          Case {cover.case_number || '—'} · Parcel {cover.parcel_id || '—'}
+        </p>
+      </div>
+      <div className="space-y-4 mt-4">
+        {template.map((section) => (
+          <div key={section.section_key} className="rounded-md overflow-hidden border border-slate-200 dark:border-slate-800">
+            <Band label={section.section_label} title={section.title} color={section.band_color} />
+            <div className="divide-y divide-slate-100 dark:divide-slate-900">
+              {SECTION_RENDERERS[section.section_key]
+                ? SECTION_RENDERERS[section.section_key](report)
+                : <Row label="Status" value={`No renderer registered for section_key '${section.section_key}'`} />}
+            </div>
+            <LiabilityNote note={(section as any).liability_note} />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/lib/biddeed-mcp.ts
+++ b/lib/biddeed-mcp.ts
@@ -1,0 +1,89 @@
+// Server-only client for the BidDeed MCP report engine — the SSOT for S5
+// report math (packages/biddeed-mcp/src/report/composer.js in cli-anything-biddeed).
+// ZoneWise never reimplements composer.js; it fetches the finished JSON.
+//
+// GET {base}/report/json?mca_id=... returns { mca_id, report } where `report`
+// is the exact S5 object produced by buildReport() — same auth as /mcp
+// (Authorization: Bearer bd_live_xxx), no billing (see biddeed-mcp/src/http.js
+// handleReportJsonRequest).
+import { createServiceClient } from '@/lib/supabase/server'
+
+const MCP_BASE_URL = (process.env.BIDDEED_MCP_BASE_URL || 'https://mcp.biddeed.ai').replace(/\/$/, '')
+
+// Allow-listed per CLAUDE.md CREDENTIAL HANDLING (GTM-22D) — cli_anything_get_secret
+// only returns names matching cli_anything_shared_secret / everest_*_pat / cli_anything_*.
+const VAULT_SECRET_NAME = 'cli_anything_biddeed_mcp_server_key'
+
+export type ServerKeySource = 'vault' | 'env' | 'none'
+
+let cachedKey: { value: string; source: ServerKeySource } | null = null
+
+// Resolves the server-held bd_live_ key used to call the MCP report engine.
+// Never logs or returns the raw value to a caller outside this module — only
+// the source label is safe to surface (e.g. in API responses / UI copy).
+export async function resolveServerKey(): Promise<{ key: string | null; source: ServerKeySource }> {
+  if (cachedKey) return { key: cachedKey.value, source: cachedKey.source }
+
+  // (a) Sanctioned vault accessor. Never SELECT vault.decrypted_secrets directly
+  // (retired per GTM-22D — that pattern caused the 2026-07-19 credential leak).
+  try {
+    const supabase = createServiceClient()
+    const { data, error } = await supabase.rpc('cli_anything_get_secret', { name: VAULT_SECRET_NAME })
+    const value = typeof data === 'string' ? data : null
+    if (!error && value && value.startsWith('bd_live_')) {
+      cachedKey = { value, source: 'vault' }
+      return { key: value, source: 'vault' }
+    }
+  } catch {
+    // RPC unavailable or secret not present — fall through to env
+  }
+
+  // (b) env var, set by Ariel on the Vercel project when no vault secret exists.
+  const envKey = process.env.BIDDEED_MCP_SERVER_KEY
+  if (envKey) {
+    cachedKey = { value: envKey, source: 'env' }
+    return { key: envKey, source: 'env' }
+  }
+
+  return { key: null, source: 'none' }
+}
+
+export interface S5ReportEnvelope {
+  mca_id: string
+  report: Record<string, unknown>
+}
+
+export type S5ReportResult =
+  | { ok: true; data: S5ReportEnvelope; keySource: ServerKeySource }
+  | { ok: false; status: number; error: string; keySource: ServerKeySource }
+
+// Fetches the full S5 report JSON for a given multi_county_auctions.id.
+// `report` is composer.js's output verbatim — v_s5_report_template.report_field
+// keys index into it directly, so the SSOT stays the DB view, not this function.
+export async function fetchS5Report(mcaId: string): Promise<S5ReportResult> {
+  const { key, source } = await resolveServerKey()
+  if (!key) {
+    return { ok: false, status: 0, error: 'server key not configured', keySource: source }
+  }
+
+  try {
+    const res = await fetch(`${MCP_BASE_URL}/report/json?mca_id=${encodeURIComponent(mcaId)}`, {
+      headers: { Authorization: `Bearer ${key}` },
+      signal: AbortSignal.timeout(20_000),
+      cache: 'no-store',
+    })
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}))
+      return { ok: false, status: res.status, error: body?.error || `HTTP ${res.status}`, keySource: source }
+    }
+    const data = (await res.json()) as S5ReportEnvelope
+    return { ok: true, data, keySource: source }
+  } catch (err) {
+    return {
+      ok: false,
+      status: 0,
+      error: err instanceof Error ? err.message : 'fetch failed',
+      keySource: source,
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- New `/report?mca_id=<id>` (or `?address=`) path renders the full BidDeed S5 18-section property intelligence report as HTML. Data comes from the BidDeed MCP report engine's `GET /report/json?mca_id=` endpoint (the composer.js SSOT — never forked/reimplemented here), rendered against `public.v_s5_report_template` ordered by `sort_order`.
- Server-side entitlement gate (`lib/biddeed-mcp.ts` + `app/api/report/route.ts`): Clerk `auth()` + `subscriptions` table, same pattern as `app/api/zoning-chat/route.ts`'s CRIT-3 fix. Non-Pro callers never trigger the MCP fetch — the full report JSON is simply never produced for that request, not filtered after the fact.
- Server key resolution: (a) sanctioned vault accessor `cli_anything_get_secret('cli_anything_biddeed_mcp_server_key')`, (b) `BIDDEED_MCP_SERVER_KEY` env var, (c) graceful "report data pending — server key not configured" state. Never hardcoded, never logged.
- The **existing** `/report?parcel=` ZoneWise zoning-report flow (used throughout the app sidebar/chatbot/PropertyCard/ParcelDetail) is untouched. Bare `/report` with no params now shows a picker instead of `notFound()`.

## Server key status (Ariel action needed)
`cli_anything_get_secret('cli_anything_biddeed_mcp_server_key')` returned no value in this session (RPC either doesn't exist yet or the secret isn't seeded) — **UNTESTED against live vault**, code falls through cleanly. Until either the vault secret is added or `BIDDEED_MCP_SERVER_KEY` is set on the Vercel project, `/report?mca_id=` will render the "report data pending — server key not configured" state for entitled users rather than the live report. Zero risk of leaking data: this state has no report payload.

## Definition of Done
- [x] Renders all 18 section_labels (1, 2-3, 4-7, 8, 9-10, 11-14, ML, ZW, 15, 16, 17, 18) from `v_s5_report_template`, mirroring `packages/biddeed-mcp/src/report/pdf.js` section-for-section — **UNTESTED against a real `mca_id` + live server key** (no key configured in this session; verified against mocked MCP responses in `__tests__/api/report.test.ts`).
- [x] Graceful "report data pending — server key not configured" state confirmed via test (no crash).
- [x] Gating traced: non-Pro → `entitled:false`, `report:null`, **MCP fetch never called** (asserted directly in test). Pro + active subscription → full report requested with `Authorization: Bearer <key>`.
- [x] `grep -rn dangerouslySetInnerHTML` on all new files → zero matches.
- [x] `tsc --noEmit`: 33 pre-existing baseline errors on `main`, 33 after this branch — no new errors introduced by these files.
- [x] `vitest run`: 163/163 passing (158 baseline + 5 new in `__tests__/api/report.test.ts`), 27/27 files green.

## Negative test
`__tests__/api/report.test.ts` — "signed-out caller never triggers the MCP report fetch and gets no report data" and "signed-in caller without an active subscription is treated as non-Pro" both assert `entitled:false`, `report:null`, and `global.fetch` never called, proving server-side gating holds even when a valid `BIDDEED_MCP_SERVER_KEY` is present in the environment.

## Non-goals honored
- No fork of composer.js math — all report content comes from the MCP `/report/json` response.
- No changes to `ChatWidget.tsx` / `ZoningChatbot.tsx` / `VoiceZoningAssistant.tsx`.
- No hardcoded `bd_live_` key anywhere in source.
- No changes to billing or `.semgrepignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
