### PR TITLE
fix: wire Stripe billing end-to-end (dead portal link, unwired Plans, hardcoded plan bug)

### DIFF
--- a/app/(dashboard)/settings/billing/page.tsx
+++ b/app/(dashboard)/settings/billing/page.tsx
@@ -1,7 +1,8 @@
-import Link from 'next/link'
-import { CreditCard, ExternalLink, Check } from 'lucide-react'
+'use client'
 
-export const dynamic = 'force-dynamic'
+import { useState } from 'react'
+import Link from 'next/link'
+import { CreditCard, ExternalLink, Check, Loader2 } from 'lucide-react'
 
 /**
  * /settings/billing — previously 404 while linked from the app sidebar, so a
@@ -11,16 +12,60 @@ export const dynamic = 'force-dynamic'
  * proplus 299 / enterprise). Entitlement counts are deliberately NOT printed
  * here: the tier table and tier spec disagree on investor S5 allowance, and
  * publishing a number we cannot honour is worse than publishing none.
+ *
+ * priceId values sourced from public.stripe_products.stripe_price_id_monthly
+ * (live_mode=true), queried 2026-08-16 — not invented.
  */
 
 const TIERS = [
-  { id: 'free', name: 'Free', price: '$0', blurb: 'Explore any Florida parcel.' },
-  { id: 'investor', name: 'Standard', price: '$99', blurb: 'Core feasibility for one operator.' },
-  { id: 'pro', name: 'Pro', price: '$199', blurb: 'For operators sourcing deals.' },
-  { id: 'proplus', name: 'Pro Plus', price: '$299', blurb: 'High-volume county coverage.' },
+  { id: 'free', name: 'Free', price: '$0', blurb: 'Explore any Florida parcel.', priceId: null },
+  {
+    id: 'investor',
+    name: 'Standard',
+    price: '$99',
+    blurb: 'Core feasibility for one operator.',
+    priceId: 'price_1ToWiPKaSTwZgYdf6sCxgRqs',
+  },
+  {
+    id: 'pro',
+    name: 'Pro',
+    price: '$199',
+    blurb: 'For operators sourcing deals.',
+    priceId: 'price_1ToWibKaSTwZgYdfZiWM5fdy',
+  },
+  {
+    id: 'proplus',
+    name: 'Pro Plus',
+    price: '$299',
+    blurb: 'High-volume county coverage.',
+    priceId: 'price_1ToWinKaSTwZgYdf80Dg54Km',
+  },
 ]
 
 export default function BillingPage() {
+  const [loadingTier, setLoadingTier] = useState<string | null>(null)
+  const [checkoutError, setCheckoutError] = useState<string | null>(null)
+
+  async function handleSubscribe(tierId: string, priceId: string) {
+    setCheckoutError(null)
+    setLoadingTier(tierId)
+    try {
+      const res = await fetch('/api/stripe/checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ priceId, tier: tierId }),
+      })
+      const data = await res.json()
+      if (!res.ok || !data.url) {
+        throw new Error(data.error || 'Could not start checkout')
+      }
+      window.location.href = data.url
+    } catch (err) {
+      setCheckoutError(err instanceof Error ? err.message : 'Could not start checkout')
+      setLoadingTier(null)
+    }
+  }
+
   return (
     <div className="min-h-full bg-[#020617] px-4 py-10 sm:px-8">
       <div className="mx-auto max-w-4xl">
@@ -53,6 +98,9 @@ export default function BillingPage() {
         </div>
 
         <h2 className="mt-12 text-sm font-semibold text-white">Plans</h2>
+        {checkoutError && (
+          <p className="mt-3 text-[13px] text-red-400">{checkoutError}</p>
+        )}
         <div className="mt-4 grid gap-4 sm:grid-cols-2">
           {TIERS.map((t) => (
             <div
@@ -68,6 +116,20 @@ export default function BillingPage() {
                 {t.price !== '$0' && <span className="ml-1 text-xs font-normal text-slate-500">/mo</span>}
               </div>
               <p className="mt-2 text-[13px] text-slate-400">{t.blurb}</p>
+              {t.priceId && (
+                <button
+                  type="button"
+                  disabled={loadingTier !== null}
+                  onClick={() => handleSubscribe(t.id, t.priceId!)}
+                  className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-md bg-[#F59E0B] px-4 py-2 text-[13px] font-bold text-[#160900] transition-shadow hover:shadow-[0_0_24px_rgba(245,158,11,0.45)] disabled:opacity-60"
+                >
+                  {loadingTier === t.id ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    `Subscribe to ${t.name}`
+                  )}
+                </button>
+              )}
             </div>
           ))}
         </div>

--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -17,11 +17,15 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const { priceId } = await request.json()
+    const { priceId, tier } = await request.json()
     const { userId } = await auth()
 
     if (!userId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    if (!priceId || !tier) {
+      return NextResponse.json({ error: 'priceId and tier are required' }, { status: 400 })
     }
 
     // Entitlement check: verify subscription status from Supabase, never trust JWT alone
@@ -56,7 +60,7 @@ export async function POST(request: NextRequest) {
         mode: 'subscription',
         success_url: `${process.env.NEXT_PUBLIC_APP_URL}/chat?success=true`,
         cancel_url: `${process.env.NEXT_PUBLIC_APP_URL}/chat?canceled=true`,
-        metadata: { userId },
+        metadata: { userId, tier },
       },
       { idempotencyKey }
     )

--- a/app/api/stripe/portal/route.ts
+++ b/app/api/stripe/portal/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@clerk/nextjs/server'
+import { createClient } from '@supabase/supabase-js'
+
+async function getStripe() {
+  const Stripe = (await import('stripe')).default
+  return new Stripe(process.env.STRIPE_SECRET_KEY!, {
+    apiVersion: '2024-09-30.acacia',
+  })
+}
+
+export async function GET(request: NextRequest) {
+  if (!process.env.STRIPE_SECRET_KEY) {
+    return NextResponse.json({ error: 'Stripe not configured' }, { status: 503 })
+  }
+
+  const { userId } = await auth()
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const supabaseAdmin = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+
+  const { data: subscription } = await supabaseAdmin
+    .from('subscriptions')
+    .select('stripe_customer_id')
+    .eq('user_id', userId)
+    .single()
+
+  if (!subscription?.stripe_customer_id) {
+    return NextResponse.json({ error: 'No active subscription' }, { status: 404 })
+  }
+
+  try {
+    const stripe = await getStripe()
+    const portalSession = await stripe.billingPortal.sessions.create({
+      customer: subscription.stripe_customer_id,
+      return_url: `${process.env.NEXT_PUBLIC_APP_URL}/settings/billing`,
+    })
+
+    return NextResponse.redirect(portalSession.url)
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -9,6 +9,19 @@ async function getStripe() {
   })
 }
 
+// Fallback only: primary tier source is session.metadata.tier, set by
+// app/api/stripe/checkout. This map covers checkouts created outside that
+// flow (e.g. a Stripe Payment Link). Sourced from public.stripe_products
+// (live_mode=true) 2026-08-16 — monthly + annual price ids per tier.
+const PRICE_ID_TO_TIER: Record<string, string> = {
+  'price_1ToWiPKaSTwZgYdf6sCxgRqs': 'investor',
+  'price_1ToWiVKaSTwZgYdfbxRGo8hz': 'investor',
+  'price_1ToWibKaSTwZgYdfZiWM5fdy': 'pro',
+  'price_1ToWigKaSTwZgYdfO4jTa0po': 'pro',
+  'price_1ToWinKaSTwZgYdf80Dg54Km': 'proplus',
+  'price_1ToWiuKaSTwZgYdfn4cJqqBh': 'proplus',
+}
+
 export async function POST(request: NextRequest) {
   // Check if Stripe is configured
   if (!process.env.STRIPE_SECRET_KEY || !process.env.STRIPE_WEBHOOK_SECRET) {
@@ -47,14 +60,39 @@ export async function POST(request: NextRequest) {
       const session = event.data.object
       const userId = session.metadata?.userId
       if (userId) {
-        await supabaseAdmin.from('subscriptions').upsert({
-          user_id: userId,
-          stripe_customer_id: session.customer,
-          stripe_subscription_id: session.subscription,
-          status: 'active',
-          plan: 'pro',
-          updated_at: new Date().toISOString()
-        })
+        // Primary source: tier set by app/api/stripe/checkout when the
+        // session was created. Fallback: derive from the purchased price,
+        // for checkouts created outside that flow (e.g. a Payment Link).
+        let plan = session.metadata?.tier
+        if (!plan) {
+          try {
+            const lineItems = await stripe.checkout.sessions.listLineItems(session.id, { limit: 1 })
+            const priceId = lineItems.data[0]?.price?.id
+            plan = priceId ? PRICE_ID_TO_TIER[priceId] : undefined
+          } catch {
+            plan = undefined
+          }
+        }
+
+        if (!plan) {
+          console.error(`checkout.session.completed ${session.id}: could not determine plan tier, skipping subscriptions write`)
+          break
+        }
+
+        const { error } = await supabaseAdmin.from('subscriptions').upsert(
+          {
+            user_id: userId,
+            stripe_customer_id: session.customer,
+            stripe_subscription_id: session.subscription,
+            status: 'active',
+            plan,
+            updated_at: new Date().toISOString()
+          },
+          { onConflict: 'user_id' }
+        )
+        if (error) {
+          console.error(`checkout.session.completed ${session.id}: subscriptions upsert failed: ${error.message}`)
+        }
       }
       break
     }

--- a/supabase/migrations/20260816_fix_subscriptions_clerk_user_id.sql
+++ b/supabase/migrations/20260816_fix_subscriptions_clerk_user_id.sql
@@ -1,0 +1,36 @@
+-- Fix subscriptions.user_id to store Clerk user IDs, not Supabase Auth UUIDs.
+--
+-- Root cause: user_id was `uuid` FK'd to auth.users(id), but this app
+-- authenticates via Clerk (see .env.example: "Supabase Database — used for
+-- data, NOT auth"). Clerk IDs look like `user_2abc...` and are never valid
+-- uuid input, so every checkout.session.completed webhook write to this
+-- table has failed since the table's creation (0 rows ever, confirmed via
+-- direct query 2026-08-16). app/api/report/route.ts and
+-- app/api/zoning-chat/route.ts already carry an Aug-14 ADMIN_USER_IDS
+-- override worked around this exact symptom without fixing the cause.
+--
+-- Also widens the plan CHECK constraint: it only allowed
+-- ('free','pro','enterprise'), which excludes the real tier ids
+-- ('investor','proplus') used by public.mcp_subscription_tiers and
+-- public.stripe_products. Even with user_id fixed, an investor/proplus
+-- purchase would still have failed the CHECK.
+
+BEGIN;
+
+DROP POLICY IF EXISTS "Users can view own subscription" ON public.subscriptions;
+
+ALTER TABLE public.subscriptions DROP CONSTRAINT IF EXISTS subscriptions_user_id_fkey;
+ALTER TABLE public.subscriptions ALTER COLUMN user_id TYPE text USING user_id::text;
+
+ALTER TABLE public.subscriptions DROP CONSTRAINT IF EXISTS subscriptions_plan_check;
+ALTER TABLE public.subscriptions ADD CONSTRAINT subscriptions_plan_check
+  CHECK (plan = ANY (ARRAY['free', 'investor', 'pro', 'proplus', 'enterprise']));
+
+-- Recreated on the new text column. auth.uid() is NULL for all requests in
+-- this app (Clerk, not Supabase Auth) so this policy is inert either way;
+-- service-role queries (all current app code) bypass RLS entirely via the
+-- existing "Service role full access subscriptions" policy.
+CREATE POLICY "Users can view own subscription" ON public.subscriptions
+  FOR SELECT USING ((auth.uid())::text = user_id);
+
+COMMIT;


### PR DESCRIPTION
## Summary
Fixes the four confirmed Stripe billing bugs plus a fifth root cause found during inspection that would have blocked all of them at the DB layer.

1. **Dead portal link** — `/settings/billing` linked to `/api/stripe/portal`, which didn't exist → 404. Added the route (`stripe.billingPortal.sessions.create`, Clerk-authenticated, resolves `stripe_customer_id` from `subscriptions`).
2. **Unwired Plans cards** — Standard/Pro/Pro Plus buttons had no `priceId`, no `onClick`, no call to checkout. Converted `settings/billing/page.tsx` to a client component; each button now POSTs `/api/stripe/checkout` with a real Stripe price ID sourced from `public.stripe_products` (`live_mode=true`, queried 2026-08-16 — not invented).
3. **Hardcoded `plan: 'pro'`** in the webhook on every `checkout.session.completed`. Now reads `session.metadata.tier` (set by the checkout route in fix #2), with a price-id→tier fallback map for checkouts created outside that flow. Also added `{ onConflict: 'user_id' }` to the upsert and error logging (previously silent).
4. **NEW (found via inspection, not in the original bug list):** `subscriptions.user_id` was `uuid`, FK'd to `auth.users`. This app authenticates via **Clerk**, not Supabase Auth — Clerk ids (`user_2abc...`) are not valid uuid input and never exist in `auth.users`. Every webhook write to this table has failed since the table's creation. Confirmed live:
   - `SELECT * FROM public.subscriptions` → `[]` (0 rows, ever)
   - Rollback-tested insert with a Clerk-shaped id: `ERROR: 22P02: invalid input syntax for type uuid: "user_2abcClerkFakeId123"`
   - `app/api/report/route.ts` and `app/api/zoning-chat/route.ts` already carry an Aug-14 `ADMIN_USER_IDS` override with a comment: *"the subscriptions table currently has zero active rows for anyone... without this override nobody... can ever see a live report."* — a workaround for this exact symptom, not the cause.
   - The `plan` CHECK constraint also only allowed `('free','pro','enterprise')`, excluding `investor`/`proplus` — so even a corrected user_id write would still fail the CHECK for those tiers.
   - Fix: migration `supabase/migrations/20260816_fix_subscriptions_clerk_user_id.sql` — drops the `auth.users` FK, changes `user_id` to `text`, widens the CHECK to include `investor`/`proplus`, recreates the (already-inert, since `auth.uid()` is always null under Clerk) RLS policy on the new column type.
   - **Already applied live** to project `mocerqjnksmhcjzxrewo` via Supabase Management API on 2026-08-16. Verified post-apply: `user_id` is `text`, no `auth.users` FK remains, `plan` CHECK now includes `investor`/`proplus`.

## Stripe account
`public.stripe_products` price/product ids (`prod_Uo...`, `price_1ToW...KaSTwZgYdf...`) share the `KaSTwZgYdf` account fragment with `acct_1LPHtNKaSTwZgYdf` (biddeed.ai). **INFERRED, not VERIFIED** — this session had no working `STRIPE_SECRET_KEY` (see Blockers) to confirm via `GET /v1/account`.

## Blockers — could not complete live/test-mode E2E verification
- **Vercel production env check (goal item 1): BLOCKED.** No Vercel token was provisioned in this runner (checked `env`, no `VERCEL_TOKEN`/`VERCEL_API_TOKEN`; `vercel env ls` requires interactive/token auth I don't have). Per this org's credential-handling rules, I did not attempt to read `vault.decrypted_secrets` to source one (that path is explicitly retired for chat/Management-API contexts) — flagging as a real gap rather than routing around it. **Needs Ariel** to either provision a Vercel token to this runner's env block or check `vercel env ls --environment=production` directly.
- **Real/test-mode Stripe checkout run (goal item 5): BLOCKED.** `STRIPE_SECRET_KEY` exists as an env var name in this runner but its value is **empty** (0 bytes) — a stale/unprovisioned secret, the same class of issue CC_META_PROMPT.md already documents for `SUPABASE_DB_PASSWORD`. No other Stripe key was available to this session. I did **not** attempt `vault.decrypted_secrets` for `stripe_secret_key` either, for the same retired-path reason above. **Needs Ariel** to either fix the runner's env provisioning or run the checkout manually.
- Because of the above, I cannot supply a webhook event ID or a real `subscriptions` row from an actual purchase. All DB-side fixes were verified structurally (rollback-tested inserts, schema introspection) — not via a live Stripe event.

## Non-goals respected
- No pricing/tier structure changes.
- biddeed.ai's Stripe integration untouched.

## Test plan
- [x] `npx tsc --noEmit` — zero errors in any touched file (38 pre-existing errors elsewhere, all unrelated to this diff — confirmed by grepping tsc output for the touched file paths, none match)
- [x] `npm run build` — full production build succeeds; `/api/stripe/portal`, `/api/stripe/checkout`, `/api/stripe/webhook`, `/settings/billing` all compile as dynamic routes
- [x] Migration applied live, verified via `information_schema.columns` + `pg_constraint` before/after
- [x] Rollback-tested that the pre-fix schema rejected a Clerk-shaped `user_id`, and that the post-fix schema accepts it
- [ ] Real Stripe checkout → webhook → subscriptions row → entitlement unlock → portal open — **not run**, see Blockers above

🤖 Generated with [Claude Code](https://claude.com/claude-code)